### PR TITLE
Feat: support custom Telegram API URL (Cloudflare Workers bypass for blocked regions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   - **[Windows](#-windows)**
   - **[macOS](#-macos)**
   - **[Linux](#%EF%B8%8F-linux-ubuntu)**
+  - **[🌐 Cloudflare Workers](#-блокировка-telegram-используйте-cloudflare-workers)**
 - **[Для разработчиков](#-для-разработчиков)**
 - **[Ссылки](#-полезные-ссылки)**
 
@@ -92,6 +93,49 @@ bash <(curl -s https://raw.githubusercontent.com/alleexxeeyy/playerok-universal/
 | `pluniversal update`  | **🔵 Обновление бота**              | 
 | `pluniversal enable`  | **☑️ Включить авто-запуск бота**  |
 | `pluniversal disable` | **❌ Выключить авто-запуск бота** |
+
+## 🌐 Блокировка Telegram? Используйте Cloudflare Workers
+
+Если Telegram заблокирован в вашем регионе (Россия, Иран и т.д.), бот не сможет подключиться к `api.telegram.org`. Решение — бесплатный прокси-воркер на Cloudflare. Всё настраивается за 2 минуты.
+
+### 🚀 Быстрый старт
+
+1. Зайдите в [Cloudflare Dashboard](https://dash.cloudflare.com/) → **Workers & Pages** → **Create application** → **Create Worker**
+2. Назовите воркер, например `tg-proxy`
+3. **Полностью удалите** шаблонный код из редактора и вставьте этот:
+
+```javascript
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    const tgUrl = `https://api.telegram.org${url.pathname}${url.search}`;
+    const headers = new Headers(request.headers);
+    headers.set('Host', 'api.telegram.org');
+    return fetch(new Request(tgUrl, {
+      method: request.method, headers, body: request.body
+    }));
+  }
+}
+```
+
+4. Нажмите **Save and Deploy** ✅
+5. Скопируйте URL воркера — выглядит так: `https://tg-proxy.ваш-поддомен.workers.dev`
+
+### 🔧 Как использовать в боте
+
+При первом запуске бота, после ввода токена появится новый пункт:
+
+```
+┌────┤ Кастомный URL Telegram API (опционально) ├──────┐
+  Если Telegram заблокирован, можно указать URL
+  Cloudflare Worker-прокси вместо api.telegram.org
+  · Пример: https://tg-proxy.ваш-поддомен.workers.dev
+  · Или пропустите, нажав Enter
+```
+
+Вставьте URL вашего воркера → **Enter**. Прокси для Telegram можно пропустить (тоже Enter). Готово! 🚀
+
+> **Важно:** URL можно указать и без `https://` — бот сам допишет. Достаточно просто `tg-proxy.ваш-поддомен.workers.dev`.
 
 ## 📚 Для разработчиков
 

--- a/settings.py
+++ b/settings.py
@@ -74,7 +74,8 @@ CONFIG = SettingsFile(
         "telegram": {
             "api": {
                 "token": "",
-                "proxy": ""
+                "proxy": "",
+                "custom_api_url": ""
             },
             "bot": {
                 "password": "",

--- a/tgbot/telegrambot.py
+++ b/tgbot/telegrambot.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from colorama import Fore
 from aiogram import Bot, Dispatcher
+from aiogram.client.telegram import TelegramAPIServer
 from aiogram.types import BotCommand, InlineKeyboardMarkup
 from aiogram.client.session.aiohttp import AiohttpSession
 
@@ -43,13 +44,24 @@ class TelegramBot:
         config = sett.get("config")
         self.token = config["telegram"]["api"]["token"]
         self.proxy = config["telegram"]["api"]["proxy"]
+        self.custom_api_url = config["telegram"]["api"].get("custom_api_url", "")
+
+        if self.custom_api_url:
+            if not (self.custom_api_url.startswith("http://")
+                    or self.custom_api_url.startswith("https://")):
+                self.custom_api_url = "https://" + self.custom_api_url
+            server = TelegramAPIServer.from_base(
+                self.custom_api_url.rstrip("/")
+            )
+        else:
+            server = None
 
         if self.proxy:
             session = AiohttpSession(proxy=f"http://{self.proxy}")
         else:
             session = None
 
-        self.bot = Bot(token=self.token, session=session)
+        self.bot = Bot(token=self.token, session=session, server=server)
         self.dp = Dispatcher()
 
         self.me = None

--- a/tgbot/telegrambot.py
+++ b/tgbot/telegrambot.py
@@ -46,22 +46,22 @@ class TelegramBot:
         self.proxy = config["telegram"]["api"]["proxy"]
         self.custom_api_url = config["telegram"]["api"].get("custom_api_url", "")
 
-        if self.custom_api_url:
-            if not (self.custom_api_url.startswith("http://")
-                    or self.custom_api_url.startswith("https://")):
-                self.custom_api_url = "https://" + self.custom_api_url
-            server = TelegramAPIServer.from_base(
-                self.custom_api_url.rstrip("/")
-            )
-        else:
-            server = None
-
         if self.proxy:
             session = AiohttpSession(proxy=f"http://{self.proxy}")
         else:
             session = None
 
-        self.bot = Bot(token=self.token, session=session, server=server)
+        self.bot = Bot(token=self.token, session=session)
+
+        # Кастомный URL Telegram API — ставим на session.api,
+        # т.к. Bot() в aiogram 3.30 не принимает server=
+        if self.custom_api_url:
+            if not (self.custom_api_url.startswith("http://")
+                    or self.custom_api_url.startswith("https://")):
+                self.custom_api_url = "https://" + self.custom_api_url
+            self.bot.session.api = TelegramAPIServer.from_base(
+                self.custom_api_url.rstrip("/")
+            )
         self.dp = Dispatcher()
 
         self.me = None

--- a/utils.py
+++ b/utils.py
@@ -181,7 +181,19 @@ def is_tg_bot_exists() -> bool:
         config = sett.get("config")
         token = config["telegram"]["api"]["token"]
         proxy = config["telegram"]["api"]["proxy"]
-        
+        custom_api_url = config["telegram"]["api"].get("custom_api_url", "")
+
+        if custom_api_url:
+            if not (custom_api_url.startswith("http://")
+                    or custom_api_url.startswith("https://")):
+                custom_api_url = "https://" + custom_api_url
+
+        tg_bot_api_url = (
+            custom_api_url.rstrip("/")
+            if custom_api_url
+            else "https://api.telegram.org"
+        )
+
         if proxy:
             proxies = {
                 "http": f"http://{proxy}",
@@ -189,9 +201,9 @@ def is_tg_bot_exists() -> bool:
             }
         else:
             proxies = None
-        
+
         response = requests.get(
-            f"https://api.telegram.org/bot{token}/getMe", 
+            f"{tg_bot_api_url}/bot{token}/getMe",
             proxies=proxies,
             timeout=30
         )
@@ -319,6 +331,34 @@ def configure_config():
                 config["telegram"]["api"]["token"] = token
                 sett.set("config", config)
                 print(f"\n{Fore.YELLOW}Токен Telegram бота успешно сохранён в конфиг.")
+
+                # Кастомный URL Telegram API (Cloudflare Worker и т.п.)
+                print(
+                    f"\n{Fore.LIGHTYELLOW_EX}┌────┤ "
+                    f"{Fore.LIGHTGREEN_EX}Кастомный URL Telegram API "
+                    f"{Fore.LIGHTYELLOW_EX}(опционально) ├──────┐{Fore.WHITE}"
+                    f"\n\n  Если Telegram заблокирован, можно указать URL "
+                    f"Cloudflare Worker-прокси"
+                    f"\n  (или другого reverse-proxy) вместо api.telegram.org"
+                    f"\n\n  {Fore.LIGHTWHITE_EX}· Пример: {Fore.WHITE}"
+                    f"https://tg-proxy.ваш-поддомен.workers.dev"
+                    f"\n  {Fore.LIGHTWHITE_EX}· Или пропустите, нажав Enter"
+                )
+                cust_api_url = input(
+                    f"  {Fore.WHITE}→ {Fore.LIGHTWHITE_EX}"
+                ).strip()
+                if cust_api_url:
+                    if not (cust_api_url.startswith("http://")
+                            or cust_api_url.startswith("https://")):
+                        cust_api_url = "https://" + cust_api_url
+                    config["telegram"]["api"]["custom_api_url"] = (
+                        cust_api_url.rstrip("/")
+                    )
+                    sett.set("config", config)
+                    print(
+                        f"\n{Fore.YELLOW}Кастомный URL Telegram API "
+                        f"сохранён."
+                    )
             else:
                 print(
                     f"\n{Fore.LIGHTRED_EX}Похоже, что вы ввели некорректный токен. "
@@ -434,8 +474,9 @@ def configure_config():
         )
         config["telegram"]["api"]["token"] = ""
         config["telegram"]["api"]["proxy"] = ""
+        config["telegram"]["api"]["custom_api_url"] = ""
         sett.set("config", config)
-        
+
         return configure_config()
     else:
         logger.info(f"{Fore.LIGHTYELLOW_EX}Telegram бот успешно работает.")


### PR DESCRIPTION
## Description

Users in regions where Telegram is blocked (Russia, Iran, etc.) cannot use the bot because `api.telegram.org` is inaccessible. This PR adds a **custom Telegram API URL** config option so users can route API calls through a Cloudflare Worker (or any reverse proxy) instead.

## Changes

### `settings.py`
- Added `"custom_api_url": ""` to the default `telegram.api` config

### `tgbot/telegrambot.py`
- Imported `TelegramAPIServer` from aiogram
- When `custom_api_url` is set, aiogram uses it instead of the default `https://api.telegram.org`
- Auto-prepends `https://` if the scheme is missing

### `utils.py`
- `is_tg_bot_exists()` — sends the `getMe` request to the custom URL when configured
- `configure_config()` — prompts for a custom API URL right after the token is validated (before the proxy step)
- Resets `custom_api_url` on validation failure together with token and proxy

## Usage

1. Deploy a Cloudflare Worker that proxies `api.telegram.org`
2. During setup, enter the Worker URL when prompted (e.g. `https://tg-proxy.ваш-поддомен.workers.dev`)
3. Skip the proxy step (press Enter)
4. Bot connects via the Worker — no proxy needed

## Backwards compatibility

Fully backward-compatible: when `custom_api_url` is empty (default), everything works exactly as before, hitting `api.telegram.org` directly.